### PR TITLE
Route SMS through Gupshup when available

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,14 @@ type Config struct {
 		SMSFromNumberOverride []string `info:"List of 'carrier=number' pairs, SMS messages to numbers of the provided carrier string (exact match) will use the alternate From Number."`
 	}
 
+	Gupshup struct {
+		Enable bool `public:"true" info:"Enables sending SMS notifications through the Gupshup provider."`
+
+		BaseURL string `info:"Optional override for the Gupshup SMS API base URL."`
+		APIKey  string `password:"true" info:"API key used for the Gupshup SMS API."`
+		Source  string `public:"true" info:"Sender ID or phone number registered with Gupshup."`
+	}
+
 	SMTP struct {
 		Enable bool `public:"true" info:"Enables email as a contact method."`
 
@@ -517,6 +525,10 @@ func (cfg Config) Validate() error {
 		}
 	}
 
+	if cfg.Gupshup.BaseURL != "" {
+		err = validate.Many(err, validate.AbsoluteURL("Gupshup.BaseURL", cfg.Gupshup.BaseURL))
+	}
+
 	if cfg.Mailgun.EmailDomain != "" {
 		err = validate.Many(err, validate.Email("Mailgun.EmailDomain", "example@"+cfg.Mailgun.EmailDomain))
 	}
@@ -544,6 +556,11 @@ func (cfg Config) Validate() error {
 			"AccountSID", cfg.Twilio.AccountSID,
 			"AuthToken", cfg.Twilio.AuthToken,
 			"FromNumber", cfg.Twilio.FromNumber,
+		),
+
+		validateEnable("Gupshup", cfg.Gupshup.Enable,
+			"APIKey", cfg.Gupshup.APIKey,
+			"Source", cfg.Gupshup.Source,
 		),
 
 		validateEnable("GitHub", cfg.GitHub.Enable,

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -577,7 +577,7 @@ func (db *DB) _SendMessages(ctx context.Context, send SendFunc, status StatusFun
 
 	// if twilio is disable, create an entry to notify the user
 	cfg := config.FromContext(ctx)
-	if !cfg.Twilio.Enable {
+	if !cfg.Twilio.Enable && !cfg.Gupshup.Enable {
 		rows, err := tx.StmtContext(ctx, db.failSMSVoice).QueryContext(execCtx)
 		if err != nil {
 			return errors.Wrap(err, "check for failed message")

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -80,6 +80,10 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Twilio.DisableTwoWaySMS", Type: ConfigTypeBoolean, Description: "Disables SMS reply codes for alert messages.", Value: fmt.Sprintf("%t", cfg.Twilio.DisableTwoWaySMS)},
 		{ID: "Twilio.SMSCarrierLookup", Type: ConfigTypeBoolean, Description: "Perform carrier lookup of SMS contact methods (required for SMSFromNumberOverride). Extra charges may apply.", Value: fmt.Sprintf("%t", cfg.Twilio.SMSCarrierLookup)},
 		{ID: "Twilio.SMSFromNumberOverride", Type: ConfigTypeStringList, Description: "List of 'carrier=number' pairs, SMS messages to numbers of the provided carrier string (exact match) will use the alternate From Number.", Value: strings.Join(cfg.Twilio.SMSFromNumberOverride, "\n")},
+		{ID: "Gupshup.Enable", Type: ConfigTypeBoolean, Description: "Enables sending SMS notifications through the Gupshup provider.", Value: fmt.Sprintf("%t", cfg.Gupshup.Enable)},
+		{ID: "Gupshup.BaseURL", Type: ConfigTypeString, Description: "Optional override for the Gupshup SMS API base URL.", Value: cfg.Gupshup.BaseURL},
+		{ID: "Gupshup.APIKey", Type: ConfigTypeString, Description: "API key used for the Gupshup SMS API.", Value: cfg.Gupshup.APIKey, Password: true},
+		{ID: "Gupshup.Source", Type: ConfigTypeString, Description: "Sender ID or phone number registered with Gupshup.", Value: cfg.Gupshup.Source},
 		{ID: "SMTP.Enable", Type: ConfigTypeBoolean, Description: "Enables email as a contact method.", Value: fmt.Sprintf("%t", cfg.SMTP.Enable)},
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
 		{ID: "SMTP.Address", Type: ConfigTypeString, Description: "The server address to use for sending email. Port is optional and defaults to 465, or 25 if Disable TLS is set. Common ports are: 25 or 587 for STARTTLS (or unencrypted) and 465 for TLS.", Value: cfg.SMTP.Address},
@@ -120,6 +124,8 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.FromNumber", Type: ConfigTypeString, Description: "The Twilio number to use for outgoing notifications.", Value: cfg.Twilio.FromNumber},
 		{ID: "Twilio.MessagingServiceSID", Type: ConfigTypeString, Description: "If set, replaces the use of From Number for SMS notifications.", Value: cfg.Twilio.MessagingServiceSID},
+		{ID: "Gupshup.Enable", Type: ConfigTypeBoolean, Description: "Enables sending SMS notifications through the Gupshup provider.", Value: fmt.Sprintf("%t", cfg.Gupshup.Enable)},
+		{ID: "Gupshup.Source", Type: ConfigTypeString, Description: "Sender ID or phone number registered with Gupshup.", Value: cfg.Gupshup.Source},
 		{ID: "SMTP.Enable", Type: ConfigTypeBoolean, Description: "Enables email as a contact method.", Value: fmt.Sprintf("%t", cfg.SMTP.Enable)},
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
@@ -349,6 +355,18 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Twilio.SMSCarrierLookup = val
 		case "Twilio.SMSFromNumberOverride":
 			cfg.Twilio.SMSFromNumberOverride = parseStringList(v.Value)
+		case "Gupshup.Enable":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Gupshup.Enable = val
+		case "Gupshup.BaseURL":
+			cfg.Gupshup.BaseURL = v.Value
+		case "Gupshup.APIKey":
+			cfg.Gupshup.APIKey = v.Value
+		case "Gupshup.Source":
+			cfg.Gupshup.Source = v.Value
 		case "SMTP.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/notification/gupshup/client.go
+++ b/notification/gupshup/client.go
@@ -1,0 +1,127 @@
+package gupshup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const defaultBaseURL = "https://api.gupshup.io/sm/api/v1/msg"
+
+// Config represents the configuration needed to interact with the Gupshup SMS API.
+type Config struct {
+	BaseURL    string
+	APIKey     string
+	Source     string
+	HTTPClient *http.Client
+}
+
+// Client can send SMS messages using the Gupshup API.
+type Client struct {
+	baseURL string
+	apiKey  string
+	source  string
+	client  *http.Client
+}
+
+// NewClient creates a new Gupshup client using the provided configuration.
+func NewClient(cfg Config) *Client {
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  cfg.APIKey,
+		source:  cfg.Source,
+		client:  httpClient,
+	}
+}
+
+// SendSMS sends a single SMS message using the Gupshup API and returns the provider message ID when available.
+func (c *Client) SendSMS(ctx context.Context, destination, message string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("gupshup client is not configured")
+	}
+
+	values := url.Values{}
+	values.Set("channel", "SMS")
+	values.Set("source", c.source)
+	values.Set("destination", destination)
+	values.Set("message", message)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build gupshup request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if c.apiKey != "" {
+		req.Header.Set("apikey", c.apiKey)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("send gupshup request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read gupshup response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("gupshup request failed: %s", strings.TrimSpace(string(body)))
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err == nil {
+		if msgID, ok := lookupString(data, "messageId"); ok {
+			return msgID, nil
+		}
+		if respObj, ok := lookupMap(data, "response"); ok {
+			if msgID, ok := lookupString(respObj, "msgId"); ok {
+				return msgID, nil
+			}
+			if msgID, ok := lookupString(respObj, "messageId"); ok {
+				return msgID, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+func lookupMap(m map[string]any, key string) (map[string]any, bool) {
+	v, ok := m[key]
+	if !ok {
+		return nil, false
+	}
+	mv, ok := v.(map[string]any)
+	return mv, ok
+}
+
+func lookupString(m map[string]any, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/notification/gupshup/client_test.go
+++ b/notification/gupshup/client_test.go
@@ -1,0 +1,119 @@
+package gupshup
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type requestInfo struct {
+	method string
+	header http.Header
+	form   url.Values
+}
+
+func TestClientSendSMS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		status      int
+		response    string
+		apiKey      string
+		wantID      string
+		wantErr     bool
+		validateReq func(t *testing.T, info requestInfo)
+	}{
+		{
+			name:     "TopLevelMessageID",
+			status:   http.StatusOK,
+			response: `{"messageId":"msg-123"}`,
+			apiKey:   "secret",
+			wantID:   "msg-123",
+			validateReq: func(t *testing.T, info requestInfo) {
+				require.Equal(t, http.MethodPost, info.method)
+				require.Equal(t, "application/x-www-form-urlencoded", info.header.Get("Content-Type"))
+				require.Equal(t, "secret", info.header.Get("apikey"))
+				require.Equal(t, "SMS", info.form.Get("channel"))
+				require.Equal(t, "source", info.form.Get("source"))
+				require.Equal(t, "+15555550123", info.form.Get("destination"))
+				require.Equal(t, "hello world", info.form.Get("message"))
+			},
+		},
+		{
+			name:     "NestedResponse",
+			status:   http.StatusOK,
+			response: `{"response":{"msgId":"msg-999"}}`,
+			wantID:   "msg-999",
+			validateReq: func(t *testing.T, info requestInfo) {
+				require.Equal(t, "", info.header.Get("apikey"))
+			},
+		},
+		{
+			name:     "InvalidJSON",
+			status:   http.StatusOK,
+			response: `not-json`,
+		},
+		{
+			name:     "HTTPError",
+			status:   http.StatusBadGateway,
+			response: `{"code":"123","message":"error"}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured requestInfo
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				vals, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+
+				captured = requestInfo{
+					method: r.Method,
+					header: r.Header.Clone(),
+					form:   vals,
+				}
+
+				if tc.status != 0 {
+					w.WriteHeader(tc.status)
+				}
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer srv.Close()
+
+			client := NewClient(Config{
+				BaseURL:    srv.URL,
+				APIKey:     tc.apiKey,
+				Source:     "source",
+				HTTPClient: srv.Client(),
+			})
+
+			id, err := client.SendSMS(context.Background(), "+15555550123", "hello world")
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantID, id)
+
+			if tc.validateReq != nil {
+				tc.validateReq(t, captured)
+			}
+		})
+	}
+}

--- a/notification/twilio/nfydestsms.go
+++ b/notification/twilio/nfydestsms.go
@@ -20,14 +20,16 @@ var _ nfydest.Provider = (*SMS)(nil)
 func (s *SMS) ID() string { return DestTypeTwilioSMS }
 func (s *SMS) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
 	cfg := config.FromContext(ctx)
+	supportsStatus := cfg.Twilio.Enable && !cfg.Gupshup.Enable
+
 	return &nfydest.TypeInfo{
 		Type:                       DestTypeTwilioSMS,
 		Name:                       "Text Message (SMS)",
-		Enabled:                    cfg.Twilio.Enable,
+		Enabled:                    cfg.Twilio.Enable || cfg.Gupshup.Enable,
 		UserDisclaimer:             cfg.General.NotificationDisclaimer,
 		SupportsAlertNotifications: true,
 		SupportsUserVerification:   true,
-		SupportsStatusUpdates:      true,
+		SupportsStatusUpdates:      supportsStatus,
 		UserVerificationRequired:   true,
 		RequiredFields: []nfydest.FieldConfig{{
 			FieldID:            FieldPhoneNumber,

--- a/notification/twilio/sms_gupshup_test.go
+++ b/notification/twilio/sms_gupshup_test.go
@@ -1,0 +1,138 @@
+package twilio
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/gupshup"
+	"github.com/target/goalert/notification/nfymsg"
+)
+
+func TestSendViaGupshup(t *testing.T) {
+	t.Parallel()
+
+	formCh := make(chan url.Values, 1)
+	headerCh := make(chan http.Header, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerCh <- r.Header.Clone()
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		vals, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+
+		formCh <- vals
+
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(map[string]string{"messageId": "msg-123"})
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	sms := &SMS{
+		limit:   newReplyLimiter(),
+		gupshup: gupshup.NewClient(gupshup.Config{BaseURL: srv.URL, APIKey: "secret", Source: "GSRC", HTTPClient: srv.Client()}),
+	}
+
+	cfg := config.Config{}
+	cfg.General.ApplicationName = "GoAlert"
+	cfg.General.PublicURL = "https://goalert.example"
+	cfg.Gupshup.Enable = true
+	ctx := cfg.Context(context.Background())
+
+	msg := notification.Alert{AlertID: 42, Summary: "Example alert"}
+
+	sent, err := sms.sendViaGupshup(ctx, sms.gupshup, msg, "+15555551234")
+	require.NoError(t, err)
+	require.Equal(t, notification.StateSent, sent.State)
+	require.Equal(t, "msg-123", sent.ExternalID)
+
+	hdr := <-headerCh
+	require.Equal(t, "secret", hdr.Get("apikey"))
+	require.Equal(t, "application/x-www-form-urlencoded", hdr.Get("Content-Type"))
+
+	vals := <-formCh
+	require.Equal(t, "SMS", vals.Get("channel"))
+	require.Equal(t, "GSRC", vals.Get("source"))
+	require.Equal(t, "+15555551234", vals.Get("destination"))
+
+	text := vals.Get("message")
+	require.Contains(t, text, "GoAlert: Alert #42: Example alert")
+	require.Contains(t, text, "https://goalert.example/alerts/42")
+	require.NotContains(t, text, "Reply '")
+}
+
+func TestSendMessageUsesGupshupWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	formCh := make(chan url.Values, 1)
+	headerCh := make(chan http.Header, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerCh <- r.Header.Clone()
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		vals, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+
+		formCh <- vals
+
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(map[string]string{"messageId": "msg-abc"})
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	sms := &SMS{
+		limit:   newReplyLimiter(),
+		gupshup: gupshup.NewClient(gupshup.Config{BaseURL: srv.URL, APIKey: "secret", Source: "GSRC", HTTPClient: srv.Client()}),
+	}
+
+	cfg := config.Config{}
+	cfg.General.ApplicationName = "GoAlert"
+	cfg.General.PublicURL = "https://goalert.example"
+	cfg.Twilio.Enable = true
+	cfg.Twilio.FromNumber = "+19999999999"
+	cfg.Gupshup.Enable = true
+	ctx := cfg.Context(context.Background())
+
+	dest := gadb.NewDestV1(DestTypeTwilioSMS, FieldPhoneNumber, "+15555551234")
+	msg := notification.Alert{
+		Base:      nfymsg.Base{ID: "msg-001", Dest: dest},
+		AlertID:   42,
+		Summary:   "Example alert",
+		ServiceID: "svc-123",
+	}
+
+	sent, err := sms.SendMessage(ctx, msg)
+	require.NoError(t, err)
+	require.Equal(t, notification.StateSent, sent.State)
+	require.Equal(t, "msg-abc", sent.ExternalID)
+
+	hdr := <-headerCh
+	require.Equal(t, "secret", hdr.Get("apikey"))
+	require.Equal(t, "application/x-www-form-urlencoded", hdr.Get("Content-Type"))
+
+	vals := <-formCh
+	require.Equal(t, "SMS", vals.Get("channel"))
+	require.Equal(t, "GSRC", vals.Get("source"))
+	require.Equal(t, "+15555551234", vals.Get("destination"))
+
+	text := vals.Get("message")
+	require.Contains(t, text, "GoAlert: Alert #42: Example alert")
+	require.Contains(t, text, "https://goalert.example/alerts/42")
+	require.NotContains(t, text, "Reply '")
+}


### PR DESCRIPTION
## Summary
- prefer the Gupshup client for SMS delivery even when Twilio remains enabled for voice calls
- disable SMS status updates when Gupshup is handling delivery to avoid promising reply support
- cover the preferred Gupshup path with a SendMessage unit test alongside the existing client test

## Testing
- go test ./notification/gupshup
- go test ./notification/twilio

------
https://chatgpt.com/codex/tasks/task_b_68cbeea56e14832c9312043d1d75c918